### PR TITLE
Use true yield  for pruning by default 

### DIFF
--- a/Datacard/README.md
+++ b/Datacard/README.md
@@ -61,7 +61,7 @@ python3 makeDatacard.py --years 2016,2017,2018 --prune (--doSystematics)
 ```
 The datacard will be produced using the concatenation of all `pkl` files in the `yields` directory. The `--prune` option will prune all signal processes which contribute less than 0.1% to the total signal yield in a given category. This threshold has been shown to have negligible effect on the final results but can be toggled using the `--pruneThreshold 0.001` option.
 
-The pruning by default uses the sum of weights in the input flashgg workspace. If the `NOTAG` dataset is present then you can also calculate the true yields using XS, BR and `eff x acc`. For this add the option `--doTrueYields`, ensuring that the full signal process XSBR map is defined in `tools.XSBR.py` (same as the mapping in the signal modelling).
+The pruning uses the true yield, calculated as `XS * BR * (eff*acc) * rate`, ensuring that the full signal process XSBR map is defined in `tools/XSBR.py` (same as the mapping in the signal modelling).
 
 The output is a `.txt` datacard that can be used for the final fits!
 

--- a/Datacard/makeDatacard.py
+++ b/Datacard/makeDatacard.py
@@ -18,9 +18,8 @@ def get_options():
   # For pruning processes
   parser.add_option('--prune', dest='prune', default=False, action="store_true", help="Prune proc x cat which make up less than pruneThreshold (default 0.1%) of given total category")
   parser.add_option('--pruneThreshold', dest='pruneThreshold', default=0.001, type='float', help="Threshold with which to prune proc x cat as fraction of total category yield (default=0.1%)")
-  parser.add_option('--doTrueYield', dest='doTrueYield', default=False, action="store_true", help="For pruning: use true number of expected events for proc x cat i.e. Product(XS,BR,eff*acc,lumi). If false then will just use sum of weights (= eff x acc)")
-  parser.add_option('--mass', dest='mass', default='125', help="MH mass: required for doTrueYield")
-  parser.add_option('--analysis', dest='analysis', default='tutorial', help="Analysis extension: required for doTrueYield (see ./tools/XSBR.py for example)")
+  parser.add_option('--mass', dest='mass', default='125', help="MH mass: required for pruning")
+  parser.add_option('--analysis', dest='analysis', default='tutorial', help="Analysis extension: required for pruning (see ./tools/XSBR.py for example)")
   # For yield/systematics:
   parser.add_option('--skipCOWCorr', dest='skipCOWCorr', default=False, action="store_true", help="Skip centralObjectWeight correction for events in acceptance")
   parser.add_option('--doSystematics', dest='doSystematics', default=False, action="store_true", help="Include systematics calculations and add to datacard")
@@ -100,43 +99,31 @@ if opt.prune:
   print(" ..........................................................................................")
   print(" --> Pruning processes which contribute < %.2f%% of RECO category yield"%(100*opt.pruneThreshold))
   data['prune'] = 0
-  if opt.doTrueYield:
-    print(" --> Using the true yield of process for pruning: N = Product(XS,BR,eff*acc,lumi)")
-    mask = (data['type']=='sig')
+  print(" --> Using the true yield of process for pruning: N = Product(XS,BR,eff*acc,lumi)")
+  mask = (data['type']=='sig')
 
-    # Extract XS*BR using tools.XSBR
-    data['xsbr'] = '-'
-    from tools.XSBR import *
-    XSBR = extractXSBR(data,mass=opt.mass,analysis=opt.analysis)
-    data.loc[mask,'xsbr'] = data[mask].apply(lambda x: XSBR["XS_%s"%x['procOriginal']]*XSBR['BR'], axis=1)
+  # Extract XS*BR using tools.XSBR
+  data['xsbr'] = '-'
+  from tools.XSBR import *
+  XSBR = extractXSBR(data,mass=opt.mass,analysis=opt.analysis)
+  data.loc[mask,'xsbr'] = data[mask].apply(lambda x: XSBR["XS_%s"%x['procOriginal']]*XSBR['BR'], axis=1)
 
-    # Extract eff*acc using total proc yield: strictly should include NOTAG
-    data['ea'] = '-'
-    # In HiggsDNA the sumw = eff*acc
-    data.loc[mask,'ea'] = data.loc[mask,'nominal_yield']
+  # Extract eff*acc using total proc yield: strictly should include NOTAG
+  data['ea'] = '-'
+  # In HiggsDNA the sumw = eff*acc
+  data.loc[mask,'ea'] = data.loc[mask,'nominal_yield']
 
-    # Calculate true yield
-    data.loc[mask,'true_yield'] = data[mask].apply(lambda x: x['xsbr']*x['ea']*x['rate'], axis=1)
+  # Calculate true yield
+  data.loc[mask,'true_yield'] = data[mask].apply(lambda x: x['xsbr']*x['ea']*x['rate'], axis=1)
 
-    # Extract per category tue yields
-    catTrueYields = od()
-    for cat in data.cat.unique(): catTrueYields[cat] = data[(data['cat']==cat)&(data['type']=='sig')].true_yield.sum()
+  # Extract per category tue yields
+  catTrueYields = od()
+  for cat in data.cat.unique(): catTrueYields[cat] = data[(data['cat']==cat)&(data['type']=='sig')].true_yield.sum()
 
-    # Set prune = 1 if < threshold of total cat yield
-    mask = (data['true_yield']<opt.pruneThreshold*data.apply(lambda x: catTrueYields[x['cat']], axis=1))&(data['type']=='sig')&(~data['cat'].str.contains('NOTAG'))
-    data.loc[mask,'prune'] = 1
+  # Set prune = 1 if < threshold of total cat yield
+  mask = (data['true_yield']<opt.pruneThreshold*data.apply(lambda x: catTrueYields[x['cat']], axis=1))&(data['type']=='sig')&(~data['cat'].str.contains('NOTAG'))
+  data.loc[mask,'prune'] = 1
 
-  else:
-    print(" --> Using nominal yield of process (sumEntries) for pruning")
-    mask = (data['type']=='sig')
-
-    # Extract per category yields
-    catYields = od()
-    for cat in data.cat.unique(): catYields[cat] = data[(data['cat']==cat)&(data['type']=='sig')].nominal_yield.sum()
-    
-    # Set prune = 1 if < threshold of total cat yield
-    mask = (data['nominal_yield']<opt.pruneThreshold*data.apply(lambda x: catYields[x['cat']], axis=1))&(data['type']=='sig')&(~data['cat'].str.contains('NOTAG'))
-    data.loc[mask,'prune'] = 1
 
   # Finally set all NOTAG events to be pruned
   mask = data['cat'].str.contains("NOTAG")

--- a/Datacard/makeDatacard.py
+++ b/Datacard/makeDatacard.py
@@ -108,7 +108,7 @@ if opt.prune:
   XSBR = extractXSBR(data,mass=opt.mass,analysis=opt.analysis)
   data.loc[mask,'xsbr'] = data[mask].apply(lambda x: XSBR["XS_%s"%x['procOriginal']]*XSBR['BR'], axis=1)
 
-  # Extract eff*acc using total proc yield: strictly should include NOTAG
+  # Extract eff*acc using total proc yield
   data['ea'] = '-'
   # In HiggsDNA the sumw = eff*acc
   data.loc[mask,'ea'] = data.loc[mask,'nominal_yield']
@@ -124,8 +124,7 @@ if opt.prune:
   mask = (data['true_yield']<opt.pruneThreshold*data.apply(lambda x: catTrueYields[x['cat']], axis=1))&(data['type']=='sig')&(~data['cat'].str.contains('NOTAG'))
   data.loc[mask,'prune'] = 1
 
-
-  # Finally set all NOTAG events to be pruned
+  # Prune NOTAG events if they exist
   mask = data['cat'].str.contains("NOTAG")
   data.loc[mask,'prune'] = 1
     


### PR DESCRIPTION
-  Updated pruning logic to use true yield `(XS × BR × eff × acc × lumi)` by default.
-  Cleaned up old `--doTrueYield ` option (no longer needed).
-  Improved `README.md` with updated pruning description.